### PR TITLE
Adjusted the min. required version of caxy/php-htmldiff.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "GNU General Public License V2",
     "require":{
         "php": ">=5.5.0",
-        "caxy/php-htmldiff": ">=0.0.5"
+        "caxy/php-htmldiff": ">=0.0.6"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Still for versions < 0.1.0-beta.1 the $isolatedDiffTags array needs to be extended manually (e.g. strong and em are missing).
